### PR TITLE
Fixed the translation to point to currently working projects

### DIFF
--- a/client/src/components/StatusForm/index.js
+++ b/client/src/components/StatusForm/index.js
@@ -200,7 +200,7 @@ class StatusForm extends Component {
           <div className={styles.label}>
             <FormattedMessage
               id="statusForm_projects"
-              defaultMessage="Which projects will you participate in to?"
+              defaultMessage="Which projects are you participating in?"
             />
             <span className={styles.projectsSaved}>
               {employeeProjectsSavedNotification ? 'Projektit tallennettu!' : ''}


### PR DESCRIPTION
Better if we ask what projects user is working on currently instead of what will be working on.

![pulu](https://user-images.githubusercontent.com/1412709/28826327-693b859e-76d2-11e7-81c6-1e03682e99e9.jpeg)
